### PR TITLE
Simple specfile for rpm building and systemd config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ PN		= rabe-fs-backup
 #PREFIX		?= /usr/local
 PREFIX		?= .
 BINDIR		= $(PREFIX)/bin
+LIBDIR		= $(PREFIX)/lib
 ETCDIR		?= $(PREFIX)/etc
 DOCDIR		= $(PREFIX)/share/doc/$(PN)
 MAN1DIR		= $(PREFIX)/share/man/man1
@@ -41,6 +42,9 @@ install-bin:
 	@echo 'installing main script...'
 	install -Dm755 $(PN).sh "$(BINDIR)/$(PN).sh"
 	install -Dm755 config/$(PN).conf "$(ETCDIR)/$(PN).conf"
+	@echo 'installing systemd services...'
+	install -Dm550 config/$(PN).service "$(LIBDIR)/systemd/system/$(PN).service"
+	install -Dm550 config/$(PN).timer "$(LIBDIR)/systemd/system/$(PN).timer"
 
 install-man:
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PN		= rabe-fs-backup
 #PREFIX		?= /usr/local
 PREFIX		?= .
 BINDIR		= $(PREFIX)/bin
-ETCDIR		= $(PREFIX)/etc
+ETCDIR		?= $(PREFIX)/etc
 DOCDIR		= $(PREFIX)/share/doc/$(PN)
 MAN1DIR		= $(PREFIX)/share/man/man1
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ LIBDIR		= $(PREFIX)/lib
 ETCDIR		?= $(PREFIX)/etc
 DOCDIR		= $(PREFIX)/share/doc/$(PN)
 MAN1DIR		= $(PREFIX)/share/man/man1
+UNITDIR		= $(LIBDIR)/systemd/system
 
 all:
 
@@ -43,8 +44,8 @@ install-bin:
 	install -Dm755 $(PN).sh "$(BINDIR)/$(PN).sh"
 	install -Dm755 config/$(PN).conf "$(ETCDIR)/$(PN).conf"
 	@echo 'installing systemd services...'
-	install -Dm550 config/$(PN).service "$(LIBDIR)/systemd/system/$(PN).service"
-	install -Dm550 config/$(PN).timer "$(LIBDIR)/systemd/system/$(PN).timer"
+	install -Dm550 config/$(PN).service "$(UNITDIR)/$(PN).service"
+	install -Dm550 config/$(PN).timer "$(UNITDIR)/$(PN).timer"
 
 install-man:
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,22 @@ As root:
 
 ### systemd timer
 
-        # run daily through systemd
-        systemctl enable rabe-fs-backup.timer
+	# run daily at midnight with 30 minute spread
+	systemctl enable rabe-fs-backup.timer
+
+You can change the timer to anything from [systemd.time Calendar Events](https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events) it
+is configured with `RandomizedDelaySec=30min` to help spread out the load on the server. You can override these settings as follows.
+
+	mkdir -p /etc/systemd/system/rabe-fs-backup.d/
+	cat > /etc/systemd/system/rabe-fs-backup.d/override.conf <<EOD
+	[Timer]
+	# reset repeatable element OnCalendar
+	OnCalendar=
+	# time you want this to run at
+	OnCalendar=06:00
+	# may it run exact at the specified time without any spreading
+	RandomizedDelaySec=0
+	EOD
 
 ## RPM Package
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ As root:
 	19:04:55 Success:  Backup successfully finished!
 	[root@vm-0011 ~]#
 
+## RPM Package
+
+This script is available as an RPM package for CentOS 7. We provide a pre-built version
+through the [openSUSE Build Server](https://build.opensuse.org/) as part of 
+the [home:radiorabe:backup Subproject](https://build.opensuse.org/project/show/home:radiorabe:backup). You can install it as follows.
+
+```bash
+curl -o /etc/yum.repos.d/home:radiorabe:backup.repo \
+     http://download.opensuse.org/repositories/home:/radiorabe:/backup/CentOS_7/home:radiorabe:backup.repo
+
+yum install rabe-backup
+```
+
+## Releasing
+
+New RPMs get built for all tags with a valid version. New releases are created through git.
+
+* Bump the version in rabe-backup.spec and add a new commit to master with the version bump
+* Tag this commit with the same version you used in the specfile
+* Push master and the tag to github
+* The openSUSE Build Service should get triggered and build a new package automagically
+
 ## License
 
 Radio RaBe Backup process and automation scripts is released under the terms of the

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ As root:
 	19:04:55 Success:  Backup successfully finished!
 	[root@vm-0011 ~]#
 
+### systemd timer
+
+        # run daily through systemd
+        systemctl enable rabe-fs-backup.timer
+
 ## RPM Package
 
 This script is available as an RPM package for CentOS 7. We provide a pre-built version

--- a/README.md
+++ b/README.md
@@ -60,22 +60,28 @@ As root:
 
 ### systemd timer
 
-	# run daily at midnight with 30 minute spread
-	systemctl enable rabe-fs-backup.timer
+```bash
+# run daily at midnight with 30 minute spread
+systemctl enable rabe-fs-backup.timer
+```
 
-You can change the timer to anything from [systemd.time Calendar Events](https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events) it
-is configured with `RandomizedDelaySec=30min` to help spread out the load on the server. You can override these settings as follows.
+You can change the timer to anything from [systemd.time Calendar Events](https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events).
+It is configured with [`RandomizedDelaySec=30min`](https://www.freedesktop.org/software/systemd/man/systemd.timer.html#RandomizedDelaySec=) to help spread 
+out the load on the server. You can override these settings as follows.
 
-	mkdir -p /etc/systemd/system/rabe-fs-backup.d/
-	cat > /etc/systemd/system/rabe-fs-backup.d/override.conf <<EOD
-	[Timer]
-	# reset repeatable element OnCalendar
-	OnCalendar=
-	# time you want this to run at
-	OnCalendar=06:00
-	# may it run exact at the specified time without any spreading
-	RandomizedDelaySec=0
-	EOD
+```bash
+mkdir -p /etc/systemd/system/rabe-fs-backup.d/
+
+cat > /etc/systemd/system/rabe-fs-backup.d/override.conf <<EOD
+[Timer]
+# reset repeatable element OnCalendar
+OnCalendar=
+# time you want this to run at
+OnCalendar=06:00
+# may it run exactly at the specified time without any spreading
+RandomizedDelaySec=0
+EOD
+```
 
 ## RPM Package
 

--- a/config/rabe-fs-backup.service
+++ b/config/rabe-fs-backup.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=RaBe Backup Service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/rabe-fs-backup.sh

--- a/config/rabe-fs-backup.timer
+++ b/config/rabe-fs-backup.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=Run RaBe Backup Service timer daily
+
+[Timer]
+# Run once per day
+OnCalendar=daily
+# Start immediately if last start was missed (ie when machine was down)
+Persistent=true
+# Delay timer randomly to spread out load (centos-7.3 and up only)
+RandomizedDelaySec=30min
+# Do not coalesce with other timers, no need to save power during a backup
+AccuracySec=1us
+# try waking system if possible
+WakeSystem=true
+# Specify the service to be run
+Unit=airtime-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/config/rabe-fs-backup.timer
+++ b/config/rabe-fs-backup.timer
@@ -1,8 +1,8 @@
 [Unit]
-Description=Run RaBe Backup Service timer daily
+Description=Run RaBe Backup Service daily
 
 [Timer]
-# Run once per day
+# Run once per day at midnight ("*-*-* 00:00:00")
 OnCalendar=daily
 # Start immediately if last start was missed (ie when machine was down)
 Persistent=true
@@ -12,8 +12,6 @@ RandomizedDelaySec=30min
 AccuracySec=1us
 # try waking system if possible
 WakeSystem=true
-# Specify the service to be run
-Unit=airtime-backup.service
 
 [Install]
 WantedBy=timers.target

--- a/rabe-backup.spec
+++ b/rabe-backup.spec
@@ -37,9 +37,11 @@ Source:        %{name}-%{version}.tar.gz
 BuildArch:     noarch
 
 BuildRequires: make
+BuildRequires: systemd
 
 Requires:      rsync
 Requires:      openssh-clients
+%{?systemd_requires}
 
 %description
 Radio RaBe Backup process and automation scripts.
@@ -53,16 +55,19 @@ make -j2
 %install
 make install PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir}/%{_prog_name}
 
+%post
+%systemd_post %{_prog_name}.timer
+
 %preun
-if [ $1 -eq 0 ] ; then
-  # Package removal, not upgrade
-  systemctl --no-reload disable --now %{_prog_name}.timer > /dev/null 2>&1 || :
-fi
+%systemd_preun %{_prog_name}.timer
+
+%postun
+%systemd_postun %{_prog_name}.timer
 
 %files
 %doc LICENSE README.md
 %config %{_sysconfdir}/%{_prog_name}/%{_prog_name}.conf
 %defattr(-,root,root,0755)
 %{_bindir}/%{_prog_name}.sh
-%attr(550, -, -) %{_exec_prefix}/lib/systemd/system/%{_prog_name}.service
-%attr(550, -, -) %{_exec_prefix}/lib/systemd/system/%{_prog_name}.timer
+%attr(550, -, -) %{_unitdir}/%{_prog_name}.service
+%attr(550, -, -) %{_unitdir}/%{_prog_name}.timer

--- a/rabe-backup.spec
+++ b/rabe-backup.spec
@@ -58,5 +58,5 @@ make install PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir}/%{_
 %config %{_sysconfdir}/%{_prog_name}/%{_prog_name}.conf
 %defattr(-,root,root,0755)
 %{_bindir}/%{_prog_name}.sh
-%{_exec_prefix}/lib/systemd/system/%{_prog_name}.service
-%{_exec_prefix}/lib/systemd/system/%{_prog_name}.timer
+%attr(550, -, -) %{_exec_prefix}/lib/systemd/system/%{_prog_name}.service
+%attr(550, -, -) %{_exec_prefix}/lib/systemd/system/%{_prog_name}.timer

--- a/rabe-backup.spec
+++ b/rabe-backup.spec
@@ -25,6 +25,7 @@
 #
 
 %define _repo_name backup
+%define _prog_name rabe-fs-backup
 
 Name:          rabe-backup
 Version:       0.0.0
@@ -50,10 +51,10 @@ Radio RaBe Backup process and automation scripts.
 make -j2
 
 %install
-make install PREFIX=%{buildroot}
+make install PREFIX=%{buildroot} ETCDIR=%{buildroot}%{_sysconfdir}/%{_prog_name}
 
 %files
 %doc LICENSE README.md
-%config %{_sysconfdir}/rabe-fs-backup.conf
+%config %{_sysconfdir}/%{_prog_name}/%{_prog_name}.conf
 %defattr(-,root,root,0755)
-/bin/rabe-fs-backup.sh
+/bin/%{_prog_name}.sh

--- a/rabe-backup.spec
+++ b/rabe-backup.spec
@@ -51,10 +51,10 @@ Radio RaBe Backup process and automation scripts.
 make -j2
 
 %install
-make install PREFIX=%{buildroot} ETCDIR=%{buildroot}%{_sysconfdir}/%{_prog_name}
+make install PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir}/%{_prog_name}
 
 %files
 %doc LICENSE README.md
 %config %{_sysconfdir}/%{_prog_name}/%{_prog_name}.conf
 %defattr(-,root,root,0755)
-/bin/%{_prog_name}.sh
+%{_bindir}/%{_prog_name}.sh

--- a/rabe-backup.spec
+++ b/rabe-backup.spec
@@ -53,6 +53,12 @@ make -j2
 %install
 make install PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir}/%{_prog_name}
 
+%preun
+if [ $1 -eq 0 ] ; then
+  # Package removal, not upgrade
+  systemctl --no-reload disable --now %{_prog_name}.timer > /dev/null 2>&1 || :
+fi
+
 %files
 %doc LICENSE README.md
 %config %{_sysconfdir}/%{_prog_name}/%{_prog_name}.conf

--- a/rabe-backup.spec
+++ b/rabe-backup.spec
@@ -58,3 +58,5 @@ make install PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir}/%{_
 %config %{_sysconfdir}/%{_prog_name}/%{_prog_name}.conf
 %defattr(-,root,root,0755)
 %{_bindir}/%{_prog_name}.sh
+%{_exec_prefix}/lib/systemd/system/%{_prog_name}.service
+%{_exec_prefix}/lib/systemd/system/%{_prog_name}.timer

--- a/rabe-backup.spec
+++ b/rabe-backup.spec
@@ -1,0 +1,59 @@
+# spec file for package rabe-backup
+#
+# This file is part of `Radio RaBe Backup process and automation scripts`
+#
+# Copyright (c) 2016 - 2017 Radio Bern RaBe
+#                           http://www.rabe.ch
+#
+# https://github.com/radiorabe/backup
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Please submit enhancements, bugfixes or comments via GitHub:
+# https://github.com/radiorabe/backup
+#
+
+%define _repo_name backup
+
+Name:          rabe-backup
+Version:       0.0.0
+Release:       0
+Summary:       RaBe Backup process and automation scripts
+License:       AGPLv3
+Source:        %{name}-%{version}.tar.gz
+
+BuildArch:     noarch
+
+BuildRequires: make
+
+Requires:      rsync
+Requires:      openssh-clients
+
+%description
+Radio RaBe Backup process and automation scripts.
+
+%prep
+%setup -q -n %{_repo_name}-%{version}
+
+%build
+make -j2
+
+%install
+make install PREFIX=%{buildroot}
+
+%files
+%doc LICENSE README.md
+%config %{_sysconfdir}/rabe-fs-backup.conf
+%defattr(-,root,root,0755)
+/bin/rabe-fs-backup.sh


### PR DESCRIPTION
This packages everything to a proper location and is all we need to build this on [OBS](https://build.opensuse.org/). 

I added some systemd services and timers in 6cd91400ee94b5d1a6c8bfc09cb65cded08b2a2d.

I already set up the [OBS part](https://build.opensuse.org/project/show/home:radiorabe:backup), so you only need to update the version in the rabe-backup.spec file and tag a `0.1.0` release after merging this PR and a package should get built.

Looking at the script there might be an issue with where make install puts the configuration file. It seems to be putting it into the file `/etc/rabe-fs-backup.conf` rather that creating the dir `/etc/rabe-fs-backup` with the file. I fixed this in 29d00556274c9964423cb1f0c33feee9209aa73d.

FIxes #6.