### PR TITLE
Fix package name in specfile

### DIFF
--- a/rabe-backup.spec
+++ b/rabe-backup.spec
@@ -32,7 +32,7 @@ Version:       0.0.1
 Release:       0
 Summary:       RaBe Backup process and automation scripts
 License:       AGPLv3
-Source:        %{name}-%{version}.tar.gz
+Source:        %{_repo_name}-%{version}.tar.gz
 
 BuildArch:     noarch
 


### PR DESCRIPTION
Naturally the one line that is not really testable without obs is the line that has the error in #10.

The name of the package needs to match the name on github which is already what is being used in %setup below.