### PR TITLE
Include/exclude on remote VM

### DIFF
--- a/backup-fs-vms.sh
+++ b/backup-fs-vms.sh
@@ -147,7 +147,7 @@ cat_remote_file() {
 }
 
 # function to backup custom directories specified by the remote vm
-backup_custom_dir() {
+backup_custom_dirs() {
   declare vm="$1"
 
   # fetch include and exclude files
@@ -237,7 +237,7 @@ do
   done
 
   # backup directories specified by the remote vm
-  backup_custom_dir "${i}"
+  backup_custom_dirs "${i}"
 
 if [ $errors_vm -eq 0 ];
 then

--- a/backup-fs-vms.sh
+++ b/backup-fs-vms.sh
@@ -152,13 +152,20 @@ backup_custom_dir() {
 
   # fetch include and exclude files
   local includes=$(cat_remote_file "${vm}" "${REMOTE_INCLUDE}")
-  # local excludes=$(cat_remote_file "${vm}" "${REMOTE_EXCLUDE}")
+  local excludes=$(cat_remote_file "${vm}" "${REMOTE_EXCLUDE}")
+
+  # `--relative` is required to exclude absolute paths
+  # https://superuser.com/a/625231
+  local exclude_opts="--relative"
+  for exclude in $excludes; do
+    exclude_opts="${exclude_opts} --exclude $exclude"
+  done
 
   for include in $includes; do
     syncdir="${vm}.vm-admin.int.rabe.ch:${include}"
     rsync --rsync-path="sudo /bin/rsync" \
       --rsh="${RSH_CMD}" \
-      ${RSYNC_OPTS} \
+      ${RSYNC_OPTS} ${exclude_opts} \
       "${syncdir}" "${BACKUP_DST_DIR}/${vm}"
     handle_rsync_ret "${?}" "${vm}" "${syncdir}" "${BACKUP_DST_DIR}/${vm}"
   done

--- a/backup-fs-vms.sh
+++ b/backup-fs-vms.sh
@@ -31,6 +31,10 @@ RSYNC_OPTS="--verbose --archive --recursive --acls --devices --specials --delete
 readonly REMOTE_INCLUDE="/etc/rabe-backup.include"
 readonly REMOTE_EXCLUDE="/etc/rabe-backup.exclude"
 
+if [[ "${DEBUG}" == 'true' ]]; then
+  set -o xtrace
+  RSYNC_OPTS="${RSYNC_OPTS} --dry-run"
+fi
 
 function get_vm_list()
 {
@@ -215,25 +219,7 @@ do
       $syncdir ${BACKUP_DST_DIR}/${i}
 
   fi
-  ret=$?
-  if [ $ret -eq "0" ]
-  then
-    echo "rabe-backup Sync of $syncdir to ${BACKUP_DST_DIR}/${i} successfull!"
-  elif [ $ret -eq "23" ]
-  then
-    echo "rabe-backup INFO: $syncdir does not exist."
-  elif [ $ret -eq "12" ]
-  then
-    echo "rabe-backup ERROR: Permission denied on $syncdir."
-    let "errors_vm++";
-  elif [ $ret -eq "255" ]
-  then
-    echo "rabe-backup ERROR: Host $i.vm-admin.int.rabe.ch is not online or could not be resolved."
-    let "errors_vm++";
-  else
-   echo "rabe-backup ERROR: Unknown error ($ret) occured when trying to rsync $syncdir."
-   let "errors_vm++";
-  fi
+  handle_rsync_ret "${?}" "${i}" "${syncdir}" "${BACKUP_DST_DIR}/${i}"
   done
 
   # backup directories specified by the remote vm

--- a/backup-fs-vms.sh
+++ b/backup-fs-vms.sh
@@ -162,7 +162,7 @@ backup_custom_dirs() {
   # https://superuser.com/a/625231
   local exclude_opts="--relative"
   for exclude in $excludes; do
-    exclude_opts="${exclude_opts} --exclude $exclude"
+    exclude_opts="${exclude_opts} --exclude ${exclude}"
   done
 
   for include in $includes; do


### PR DESCRIPTION
This PR adds the ability for the backupped VM to specify additional directories to include in the backup. This fixes #3.

**TODO**
- [x] exclude functionality
- [x] include functionality

@micressor could you please review the changes?

The VMs can specify additional directories by including them in `/etc/rabe-backup.include` and `/etc/rabe-backup.exclude`.

I tried to stay as non-invasive as possible and simply added the needed functionalities as functions.