### PR TITLE
feat: read zabbix server address from remote

### DIFF
--- a/backup-util.sh
+++ b/backup-util.sh
@@ -61,7 +61,7 @@ backup_success(){
   fi
   zabbix_server2="$(cat_remote_file "$hostname" "/etc/zabbix/zabbix_agent2.conf" | \
     grep "^Server=.*$" | awk -F "=" '{print $2}')"
-  if [[ -z $zabbix_server2 ]]; then
+  if [[ -n $zabbix_server2 ]]; then
     zabbix_server_arg="--zabbix-server ${zabbix_server2}"
   fi
   # send timestamp of last successful backup


### PR DESCRIPTION
So the zabbix_send call dispatches the trapper call to the Zabbix server configured on the system being backed up.

